### PR TITLE
PXY-1007 Integrating encryption in soak integration framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,12 @@ Testing your Conduktor Gateway by your own scenario (yaml file in config/scenari
 
 ## Scenario YAML File Description
 
-The [scenario3.yaml](config/scenario/scenario3.yaml) file in this config/scenario folder repository is a configuration file used to define a test workflow for testing functionalities related to SASL_SSL and Dynamic Header Injection in Conduktor Gateway. The YAML file contains various sections that define the setup and actions to be performed during the test.<br/>
+The [scenario3.yaml](config/scenario/scenario3.yaml) file in this config/scenario folder repository is a configuration
+file used to define a test workflow for testing functionalities related to SASL_SSL and Dynamic Header Injection in
+Conduktor Gateway. The YAML file contains various sections that define the setup and actions to be performed during the
+test.<br/>
 E.g:
+
 ```yaml
 title: Simple test with SASL_SSL and Dynamic Header Injection
 docker:
@@ -57,14 +61,20 @@ actions:
   - type: FETCH
     target: KAFKA
     topic: franklxtopic1
-    messages:
-      - key: "key3"
-        value: "value3"
+    assertions:
+      - key:
+          expected: "key3"
+        value:
+          expected: "value3"
         headers:
-          header_key1: "headerValue5"
-          header_key2: "headerValue5"
-          X-RAW_KEY: "a value"
-          X-USERNAME: "franklx"
+          header_key1:
+            expected: "headerValue5"
+          header_key2:
+            expected: "headerValue5"
+          X-RAW_KEY:
+            expected: "a value"
+          X-USERNAME:
+            expected: "franklx"
   - type: FETCH
     target: GATEWAY
     properties:
@@ -72,14 +82,20 @@ actions:
       sasl.mechanism: PLAIN
       sasl.jaas.config: "org.apache.kafka.common.security.plain.PlainLoginModule required username=\"franklx\" password=\"eyJhbGciOiJIUzI1NiJ9.eyJ1c2VybmFtZSI6ImZyYW5rbHgiLCJ2Y2x1c3RlciI6ImZyYW5rbHgiLCJleHAiOjExNjkyMDg4MjI0fQ.RaDEBfXwUJHKYiDeOGQ8HgLT7K9yCnNa6SckSvHZuCw\";"
     topic: topic1
-    messages:
-      - key: "key3"
-        value: "value3"
+    assertions:
+      - key:
+          expected: "key3"
+        value:
+          expected: "value3"
         headers:
-          header_key1: "headerValue5"
-          header_key2: "headerValue5"
-          X-RAW_KEY: "a value"
-          X-USERNAME: "franklx"
+          header_key1:
+            expected: "headerValue5"
+          header_key2:
+            expected: "headerValue5"
+          X-RAW_KEY:
+            expected: "a value"
+          X-USERNAME:
+            expected: "franklx"
 ```
 
 ### Title
@@ -92,7 +108,8 @@ title: Simple test with SASL_SSL and Dynamic Header Injection
 
 ### Docker Configuration
 
-The next section defines `docker` - the Docker configurations for Kafka and the Gateway Service. It specifies the versions and environment variables to be used for these containers:
+The next section defines `docker` - the Docker configurations for Kafka and the Gateway Service. It specifies the
+versions and environment variables to be used for these containers:
 
 ```yaml
 docker:
@@ -108,7 +125,8 @@ docker:
 
 ### Plugins
 
-In this `plugins` section, the YAML file defines the plugins for tenant `franklx` to be used during the test. Specifically, it sets up two instances of the `DynamicHeaderInjectionPlugin`, each with its own configuration:
+In this `plugins` section, the YAML file defines the plugins for tenant `franklx` to be used during the test.
+Specifically, it sets up two instances of the `DynamicHeaderInjectionPlugin`, each with its own configuration:
 
 ```yaml
 plugins:
@@ -133,11 +151,33 @@ plugins:
 
 The actions section contains a list of actions to be performed during the test. <br/>
 Each action specifies its:
+
 - `type` (currently support: `CREATE_TOPIC`, `PRODUCE`, `FETCH`)
 - `target` (`KAFKA`, `GATEWAY`)
 - `properties` (admin client configs, producer configs or consumer configs depends on your action type)
 - `topic` (topic name)
 - `messages` (list of messages, each messages contains `key`, `value` and `headers`)
+- `assertions` (list of assertions)
+    - `description` (string): A brief description of the assertion being made. This helps provide context and
+      understanding.
+    - `headers`(List<String, Assertion>): A map of headers and their associated assertions.
+    - key (Assertion): An instance of the `Assertion` class used to assert conditions on key or identifiers within the
+      record.
+    - value (Assertion): Another instance of the `Assertion` class used to assert conditions on value within the record.
+
+The `Assertion` defines the criteria for asserting conditions. It contains the following properties:
+
+- `operator` (String): This specifies the type of assertion operation to be performed. Possible values include:
+    - `isEqualTo`
+    - `isNotEqualTo`
+    - `satisfies`: allows you to specify complex conditions that must be met for the assertion to pass. The `expected`
+      property contains an expression written in a custom syntax that supports logical and comparison operations on data
+      attributes. For example: `'[name] == "conduktor" && [password] != "password1"'`
+    - `isNull`
+    - `isNotNull`
+    - and more
+- `expected` (Object): This property holds the expected value against which the assertion will be evaluated. It can be
+  of any data type relevant to the assertion.
 
 These actions include:
 
@@ -178,14 +218,20 @@ These actions include:
   - type: FETCH
     target: KAFKA
     topic: franklxtopic1
-    messages:
-      - key: "key3"
-        value: "value3"
+    assertions:
+      - key:
+          expected: "key3"
+        value:
+          expected: "value3"
         headers:
-          header_key1: "headerValue5"
-          header_key2: "headerValue5"
-          X-RAW_KEY: "a value"
-          X-USERNAME: "franklx"
+          header_key1:
+            expected: "headerValue5"
+          header_key2:
+            expected: "headerValue5"
+          X-RAW_KEY:
+            expected: "a value"
+          X-USERNAME:
+            expected: "franklx"
 ```
 
 #### Action 4: Fetching messages from `topic1` in the Gateway Service and expect return exactly defined messages:
@@ -198,14 +244,20 @@ These actions include:
       sasl.mechanism: PLAIN
       sasl.jaas.config: "org.apache.kafka.common.security.plain.PlainLoginModule required username=\"franklx\" password=\"eyJhbGciOiJIUzI1NiJ9.eyJ1c2VybmFtZSI6ImZyYW5rbHgiLCJ2Y2x1c3RlciI6ImZyYW5rbHgiLCJleHAiOjExNjkyMDg4MjI0fQ.RaDEBfXwUJHKYiDeOGQ8HgLT7K9yCnNa6SckSvHZuCw\";"
     topic: topic1
-    messages:
-      - key: "key3"
-        value: "value3"
+    assertions:
+      - key:
+          expected: "key3"
+        value:
+          expected: "value3"
         headers:
-          header_key1: "headerValue5"
-          header_key2: "headerValue5"
-          X-RAW_KEY: "a value"
-          X-USERNAME: "franklx"
+          header_key1:
+            expected: "headerValue5"
+          header_key2:
+            expected: "headerValue5"
+          X-RAW_KEY:
+            expected: "a value"
+          X-USERNAME:
+            expected: "franklx"
 ```
 
 # Feel free to explore and extend this repository for more test scenarios and functionalities as per your requirements!

--- a/config/scenario/scenario-encryption.yaml
+++ b/config/scenario/scenario-encryption.yaml
@@ -62,7 +62,7 @@ actions:
       sasl.jaas.config: "org.apache.kafka.common.security.plain.PlainLoginModule required username=\"franklx\" password=\"eyJhbGciOiJIUzI1NiJ9.eyJ1c2VybmFtZSI6ImZyYW5rbHgiLCJ2Y2x1c3RlciI6ImZyYW5rbHgiLCJleHAiOjExNjkyMDg4MjI0fQ.RaDEBfXwUJHKYiDeOGQ8HgLT7K9yCnNa6SckSvHZuCw\";"
     topic: encryptedTopic
     messages:
-      - value: '{"name":1,"username":"test@conduktor.io","password":"password1","visa":"visa123456","address":"Conduktor Towers, London"}'
+      - value: '{"name":"conduktor","username":"test@conduktor.io","password":"password1","visa":"visa123456","address":"Conduktor Towers, London"}'
   - type: FETCH
     target: GATEWAY
     properties:
@@ -74,7 +74,7 @@ actions:
       - description: confirm decryption at gateway
         value:
           operator: isEqualTo
-          expected: '{"name":1,"username":"test@conduktor.io","password":"password1","visa":"visa123456","address":"Conduktor Towers, London"}'
+          expected: '{"name":"conduktor","username":"test@conduktor.io","password":"password1","visa":"visa123456","address":"Conduktor Towers, London"}'
   - type: FETCH
     target: KAFKA
     topic: franklxencryptedTopic
@@ -82,4 +82,4 @@ actions:
       - description: confirm encryption at rest - only 2 fields password and visa are encrypted
         value:
           operator: satisfies
-          expected: '[name] == 1 && [username] == "test@conduktor.io" && [password] != "password1" && [visa] != "visa123456" && [address] == "Conduktor Towers, London"'
+          expected: '[name] == "conduktor" && [username] == "test@conduktor.io" && [password] != "password1" && [visa] != "visa123456" && [address] == "Conduktor Towers, London"'

--- a/config/scenario/scenario-encryption.yaml
+++ b/config/scenario/scenario-encryption.yaml
@@ -1,0 +1,87 @@
+title: Encryption
+docker:
+  kafka:
+    version: latest
+    environment:
+      KAFKA_AUTO_CREATE_TOPICS_ENABLE: false
+  gateway:
+    version: 2.0.0-amd64
+    environment:
+      GATEWAY_SECURITY_PROTOCOL: SASL_PLAINTEXT
+plugins:
+  franklx:
+    encryption-interceptor-config:
+      pluginClass: "io.conduktor.gateway.interceptor.EncryptPlugin"
+      "priority": 1
+      "config": {
+        "topic": "encryptedTopic",
+        "schemaRegistryConfig": {
+          "host": "http://schema-registry:8081"
+        },
+        "fields": [
+          {
+            "fieldName": "password",
+            "keySecretId": "secret-key-password",
+            "algorithm": {
+              "type": "AES_GCM",
+              "kms": "IN_MEMORY"
+            }
+          },
+          {
+            "fieldName": "visa",
+            "keySecretId": "secret-key-visaNumber",
+            "algorithm": {
+              "type": "AES_GCM",
+              "kms": "IN_MEMORY"
+            }
+          }
+        ]
+      }
+    decryption-interceptor-config:
+      pluginClass: "io.conduktor.gateway.interceptor.DecryptPlugin"
+      "priority": 1
+      "config": {
+        "topic": "encryptedTopic",
+        "schemaRegistryConfig": {
+          "host": "http://schema-registry:8081"
+        }
+      }
+actions:
+  - type: CREATE_TOPIC
+    target: GATEWAY
+    properties:
+      security.protocol: SASL_PLAINTEXT
+      sasl.mechanism: PLAIN
+      sasl.jaas.config: "org.apache.kafka.common.security.plain.PlainLoginModule required username=\"franklx\" password=\"eyJhbGciOiJIUzI1NiJ9.eyJ1c2VybmFtZSI6ImZyYW5rbHgiLCJ2Y2x1c3RlciI6ImZyYW5rbHgiLCJleHAiOjExNjkyMDg4MjI0fQ.RaDEBfXwUJHKYiDeOGQ8HgLT7K9yCnNa6SckSvHZuCw\";"
+    topic: encryptedTopic
+  - type: PRODUCE
+    target: GATEWAY
+    properties:
+      security.protocol: SASL_PLAINTEXT
+      sasl.mechanism: PLAIN
+      sasl.jaas.config: "org.apache.kafka.common.security.plain.PlainLoginModule required username=\"franklx\" password=\"eyJhbGciOiJIUzI1NiJ9.eyJ1c2VybmFtZSI6ImZyYW5rbHgiLCJ2Y2x1c3RlciI6ImZyYW5rbHgiLCJleHAiOjExNjkyMDg4MjI0fQ.RaDEBfXwUJHKYiDeOGQ8HgLT7K9yCnNa6SckSvHZuCw\";"
+    topic: encryptedTopic
+    messages:
+      - value: '{"name":"conduktor","username":"test@conduktor.io","password":"password1","visa":"visa123456","address":"Conduktor Towers, London"}'
+  - type: FETCH
+    target: GATEWAY
+    properties:
+      security.protocol: SASL_PLAINTEXT
+      sasl.mechanism: PLAIN
+      sasl.jaas.config: "org.apache.kafka.common.security.plain.PlainLoginModule required username=\"franklx\" password=\"eyJhbGciOiJIUzI1NiJ9.eyJ1c2VybmFtZSI6ImZyYW5rbHgiLCJ2Y2x1c3RlciI6ImZyYW5rbHgiLCJleHAiOjExNjkyMDg4MjI0fQ.RaDEBfXwUJHKYiDeOGQ8HgLT7K9yCnNa6SckSvHZuCw\";"
+    topic: encryptedTopic
+    recordAssertion:
+      title: confirm decryption at gateway
+      expectedSize: 1
+      value:
+        assertThat: isEqualTo
+        expected: '{"name":"conduktor","username":"test@conduktor.io","password":"password1","visa":"visa123456","address":"Conduktor Towers, London"}'
+  - type: FETCH
+    target: KAFKA
+    topic: franklxencryptedTopic
+    recordAssertion:
+      title: confirm encryption at rest - only 2 fields password and visa are encrypted
+      expectedSize: 1
+      value:
+        assertThat: satisfies
+        expected: '[name] == "conduktor" && [username] == "test@conduktor.io" && [password] != "password1" && [visa] != "visa123456" && [address] == "Conduktor Towers, London"'

--- a/config/scenario/scenario-encryption.yaml
+++ b/config/scenario/scenario-encryption.yaml
@@ -62,7 +62,7 @@ actions:
       sasl.jaas.config: "org.apache.kafka.common.security.plain.PlainLoginModule required username=\"franklx\" password=\"eyJhbGciOiJIUzI1NiJ9.eyJ1c2VybmFtZSI6ImZyYW5rbHgiLCJ2Y2x1c3RlciI6ImZyYW5rbHgiLCJleHAiOjExNjkyMDg4MjI0fQ.RaDEBfXwUJHKYiDeOGQ8HgLT7K9yCnNa6SckSvHZuCw\";"
     topic: encryptedTopic
     messages:
-      - value: '{"name":"conduktor","username":"test@conduktor.io","password":"password1","visa":"visa123456","address":"Conduktor Towers, London"}'
+      - value: '{"name":1,"username":"test@conduktor.io","password":"password1","visa":"visa123456","address":"Conduktor Towers, London"}'
   - type: FETCH
     target: GATEWAY
     properties:
@@ -70,18 +70,16 @@ actions:
       sasl.mechanism: PLAIN
       sasl.jaas.config: "org.apache.kafka.common.security.plain.PlainLoginModule required username=\"franklx\" password=\"eyJhbGciOiJIUzI1NiJ9.eyJ1c2VybmFtZSI6ImZyYW5rbHgiLCJ2Y2x1c3RlciI6ImZyYW5rbHgiLCJleHAiOjExNjkyMDg4MjI0fQ.RaDEBfXwUJHKYiDeOGQ8HgLT7K9yCnNa6SckSvHZuCw\";"
     topic: encryptedTopic
-    recordAssertion:
-      title: confirm decryption at gateway
-      expectedSize: 1
-      value:
-        assertThat: isEqualTo
-        expected: '{"name":"conduktor","username":"test@conduktor.io","password":"password1","visa":"visa123456","address":"Conduktor Towers, London"}'
+    assertions:
+      - description: confirm decryption at gateway
+        value:
+          operator: isEqualTo
+          expected: '{"name":1,"username":"test@conduktor.io","password":"password1","visa":"visa123456","address":"Conduktor Towers, London"}'
   - type: FETCH
     target: KAFKA
     topic: franklxencryptedTopic
-    recordAssertion:
-      title: confirm encryption at rest - only 2 fields password and visa are encrypted
-      expectedSize: 1
-      value:
-        assertThat: satisfies
-        expected: '[name] == "conduktor" && [username] == "test@conduktor.io" && [password] != "password1" && [visa] != "visa123456" && [address] == "Conduktor Towers, London"'
+    assertions:
+      - description: confirm encryption at rest - only 2 fields password and visa are encrypted
+        value:
+          operator: satisfies
+          expected: '[name] == 1 && [username] == "test@conduktor.io" && [password] != "password1" && [visa] != "visa123456" && [address] == "Conduktor Towers, London"'

--- a/config/scenario/scenario1.yaml
+++ b/config/scenario/scenario1.yaml
@@ -30,28 +30,44 @@ actions:
   - type: FETCH
     target: KAFKA
     topic: topic1
-    messages:
-      - key: "key1"
-        value: "value1"
+    assertions:
+      - key:
+          expected: "key1"
+        value:
+          expected: "value1"
         headers:
-          header_key1: "headerValue1"
-          header_key2: "headerValue2"
-      - key: "key2"
-        value: "value2"
+          header_key1:
+            expected: "headerValue1"
+          header_key2:
+            expected: "headerValue2"
+      - key:
+          expected: "key2"
+        value:
+          expected: "value2"
         headers:
-          header_key3: "headerValue3"
-          header_key4: "headerValue4"
+          header_key3:
+            expected: "headerValue3"
+          header_key4:
+            expected: "headerValue4"
   - type: FETCH
     target: GATEWAY
     topic: topic1
     messages:
-      - key: "key1"
-        value: "value1"
+      - key:
+          expected: "key1"
+        value:
+          expected: "value1"
         headers:
-          header_key1: "headerValue1"
-          header_key2: "headerValue2"
-      - key: "key2"
-        value: "value2"
+          header_key1:
+            expected: "headerValue1"
+          header_key2:
+            expected: "headerValue2"
+      - key:
+          expected: "key2"
+        value:
+          expected: "value2"
         headers:
-          header_key3: "headerValue3"
-          header_key4: "headerValue4"
+          header_key3:
+            expected: "headerValue3"
+          header_key4:
+            expected: "headerValue4"

--- a/config/scenario/scenario1.yaml
+++ b/config/scenario/scenario1.yaml
@@ -52,7 +52,7 @@ actions:
   - type: FETCH
     target: GATEWAY
     topic: topic1
-    messages:
+    assertions:
       - key:
           expected: "key1"
         value:

--- a/config/scenario/scenario2.yaml
+++ b/config/scenario/scenario2.yaml
@@ -42,12 +42,17 @@ actions:
     target: KAFKA
     topic: franklxtopic1
     messages:
-      - key: "key3"
-        value: "value3"
+      - key:
+          expected: "key3"
+        value:
+          expected: "value3"
         headers:
-          header_key1: "headerValue5"
-          header_key2: "headerValue5"
-          X-USERNAME: "franklx for SASL_PLAINTEXT"
+          header_key1:
+            expected: "headerValue5"
+          header_key2:
+            expected: "headerValue5"
+          X-USERNAME:
+            expected: "franklx for SASL_PLAINTEXT"
   - type: FETCH
     target: GATEWAY
     properties:
@@ -56,9 +61,14 @@ actions:
       sasl.jaas.config: "org.apache.kafka.common.security.plain.PlainLoginModule required username=\"franklx\" password=\"eyJhbGciOiJIUzI1NiJ9.eyJ1c2VybmFtZSI6ImZyYW5rbHgiLCJ2Y2x1c3RlciI6ImZyYW5rbHgiLCJleHAiOjExNjkyMDg4MjI0fQ.RaDEBfXwUJHKYiDeOGQ8HgLT7K9yCnNa6SckSvHZuCw\";"
     topic: topic1
     messages:
-      - key: "key3"
-        value: "value3"
+      - key:
+          expected: "key3"
+        value:
+          expected: "value3"
         headers:
-          header_key1: "headerValue5"
-          header_key2: "headerValue5"
-          X-USERNAME: "franklx for SASL_PLAINTEXT"
+          header_key1:
+            expected: "headerValue5"
+          header_key2:
+            expected: "headerValue5"
+          X-USERNAME:
+            expected: "franklx for SASL_PLAINTEXT"

--- a/config/scenario/scenario2.yaml
+++ b/config/scenario/scenario2.yaml
@@ -41,7 +41,7 @@ actions:
   - type: FETCH
     target: KAFKA
     topic: franklxtopic1
-    messages:
+    assertions:
       - key:
           expected: "key3"
         value:
@@ -60,7 +60,7 @@ actions:
       sasl.mechanism: PLAIN
       sasl.jaas.config: "org.apache.kafka.common.security.plain.PlainLoginModule required username=\"franklx\" password=\"eyJhbGciOiJIUzI1NiJ9.eyJ1c2VybmFtZSI6ImZyYW5rbHgiLCJ2Y2x1c3RlciI6ImZyYW5rbHgiLCJleHAiOjExNjkyMDg4MjI0fQ.RaDEBfXwUJHKYiDeOGQ8HgLT7K9yCnNa6SckSvHZuCw\";"
     topic: topic1
-    messages:
+    assertions:
       - key:
           expected: "key3"
         value:

--- a/config/scenario/scenario3.yaml
+++ b/config/scenario/scenario3.yaml
@@ -48,7 +48,7 @@ actions:
   - type: FETCH
     target: KAFKA
     topic: franklxtopic1
-    messages:
+    assertions:
       - key:
           expected: "key3"
         value:
@@ -69,7 +69,7 @@ actions:
       sasl.mechanism: PLAIN
       sasl.jaas.config: "org.apache.kafka.common.security.plain.PlainLoginModule required username=\"franklx\" password=\"eyJhbGciOiJIUzI1NiJ9.eyJ1c2VybmFtZSI6ImZyYW5rbHgiLCJ2Y2x1c3RlciI6ImZyYW5rbHgiLCJleHAiOjExNjkyMDg4MjI0fQ.RaDEBfXwUJHKYiDeOGQ8HgLT7K9yCnNa6SckSvHZuCw\";"
     topic: topic1
-    messages:
+    assertions:
       - key:
           expected: "key3"
         value:

--- a/config/scenario/scenario3.yaml
+++ b/config/scenario/scenario3.yaml
@@ -49,13 +49,19 @@ actions:
     target: KAFKA
     topic: franklxtopic1
     messages:
-      - key: "key3"
-        value: "value3"
+      - key:
+          expected: "key3"
+        value:
+          expected: "value3"
         headers:
-          header_key1: "headerValue5"
-          header_key2: "headerValue5"
-          X-RAW_KEY: "a value"
-          X-USERNAME: "franklx"
+          header_key1:
+            expected: "headerValue5"
+          header_key2:
+            expected: "headerValue5"
+          X-RAW_KEY:
+            expected: "a value"
+          X-USERNAME:
+            expected: "franklx"
   - type: FETCH
     target: GATEWAY
     properties:
@@ -64,10 +70,16 @@ actions:
       sasl.jaas.config: "org.apache.kafka.common.security.plain.PlainLoginModule required username=\"franklx\" password=\"eyJhbGciOiJIUzI1NiJ9.eyJ1c2VybmFtZSI6ImZyYW5rbHgiLCJ2Y2x1c3RlciI6ImZyYW5rbHgiLCJleHAiOjExNjkyMDg4MjI0fQ.RaDEBfXwUJHKYiDeOGQ8HgLT7K9yCnNa6SckSvHZuCw\";"
     topic: topic1
     messages:
-      - key: "key3"
-        value: "value3"
+      - key:
+          expected: "key3"
+        value:
+          expected: "value3"
         headers:
-          header_key1: "headerValue5"
-          header_key2: "headerValue5"
-          X-RAW_KEY: "a value"
-          X-USERNAME: "franklx"
+          header_key1:
+            expected: "headerValue5"
+          header_key2:
+            expected: "headerValue5"
+          X-RAW_KEY:
+            expected: "a value"
+          X-USERNAME:
+            expected: "franklx"

--- a/config/scenario/scenario4.yaml
+++ b/config/scenario/scenario4.yaml
@@ -34,8 +34,12 @@ actions:
       sasl.jaas.config: "org.apache.kafka.common.security.plain.PlainLoginModule required username=\"franklx\" password=\"eyJhbGciOiJIUzI1NiJ9.eyJ1c2VybmFtZSI6ImZyYW5rbHgiLCJ2Y2x1c3RlciI6ImZyYW5rbHgiLCJleHAiOjExNjkyMDg4MjI0fQ.RaDEBfXwUJHKYiDeOGQ8HgLT7K9yCnNa6SckSvHZuCw\";"
     topic: topic1
     messages:
-      - key: "key3"
-        value: "value3"
+      - key:
+          expected: "key3"
+        value:
+          expected: "value3"
         headers:
-          header_key1: "headerValue5"
-          header_key2: "headerValue5"
+          header_key1:
+            expected: "headerValue5"
+          header_key2:
+            expected: "headerValue5"

--- a/config/scenario/scenario4.yaml
+++ b/config/scenario/scenario4.yaml
@@ -33,7 +33,7 @@ actions:
       security.protocol: SSL
       sasl.jaas.config: "org.apache.kafka.common.security.plain.PlainLoginModule required username=\"franklx\" password=\"eyJhbGciOiJIUzI1NiJ9.eyJ1c2VybmFtZSI6ImZyYW5rbHgiLCJ2Y2x1c3RlciI6ImZyYW5rbHgiLCJleHAiOjExNjkyMDg4MjI0fQ.RaDEBfXwUJHKYiDeOGQ8HgLT7K9yCnNa6SckSvHZuCw\";"
     topic: topic1
-    messages:
+    assertions:
       - key:
           expected: "key3"
         value:

--- a/pom.xml
+++ b/pom.xml
@@ -91,10 +91,27 @@
         <dependency>
             <groupId>io.rest-assured</groupId>
             <artifactId>rest-assured</artifactId>
-            <version>5.1.1</version>
+            <version>5.3.1</version>
             <scope>test</scope>
         </dependency>
-        <!-- Add other dependencies as needed -->
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-collections4</artifactId>
+            <version>4.4</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.13.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-expression</artifactId>
+            <version>6.0.11</version>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/src/test/java/io/conduktor/gateway/soak/func/ScenarioTest.java
+++ b/src/test/java/io/conduktor/gateway/soak/func/ScenarioTest.java
@@ -1,5 +1,7 @@
 package io.conduktor.gateway.soak.func;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.conduktor.gateway.soak.func.config.PluginRequest;
 import io.conduktor.gateway.soak.func.config.Scenario;
 import io.conduktor.gateway.soak.func.config.support.YamlConfigReader;
@@ -7,34 +9,43 @@ import io.conduktor.gateway.soak.func.utils.ClientFactory;
 import io.conduktor.gateway.soak.func.utils.KafkaActionUtils;
 import io.restassured.http.ContentType;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.collections4.IteratorUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.common.header.Header;
 import org.apache.kafka.common.header.internals.RecordHeader;
-import org.assertj.core.api.Assertions;
+import org.assertj.core.api.AbstractAssert;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.expression.spel.standard.SpelExpressionParser;
+import org.springframework.expression.spel.support.StandardEvaluationContext;
 
 import java.io.File;
 import java.io.IOException;
 import java.util.*;
 import java.util.concurrent.ExecutionException;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static io.conduktor.gateway.soak.func.utils.DockerComposeContainerUtils.startContainer;
 import static io.conduktor.gateway.soak.func.utils.DockerComposeContainerUtils.stopContainer;
 import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
 
 @Slf4j
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class ScenarioTest {
 
+    private static final ObjectMapper MAPPER = new ObjectMapper();
     private static final String ADMIN_USER = "admin";
     private static final String ADMIN_PASSWORD = "conduktor";
     private final static String SCENARIO_DIRECTORY_PATH = "config/scenario";
@@ -55,8 +66,10 @@ public class ScenarioTest {
                 var configReader = YamlConfigReader.forType(Scenario.class);
                 for (var file : files) {
                     if (file.isFile() && file.getName().toLowerCase().endsWith(".yaml")) {
-                        var scenario = configReader.readYamlInResources(file.getPath());
-                        scenarios.add(Arguments.of(scenario));
+                        if (file.getName().contains("scenario-encryption.yaml")) {
+                            var scenario = configReader.readYamlInResources(file.getPath());
+                            scenarios.add(Arguments.of(scenario));
+                        }
                     }
                 }
             }
@@ -99,6 +112,8 @@ public class ScenarioTest {
             var topic = action.getTopic();
             var messages = action.getMessages();
             var clientFactory = new ClientFactory();
+            var recordAssertion = action.getRecordAssertion();
+
             //TODO: refactor it to look better
             switch (type) {
                 case CREATE_TOPIC -> {
@@ -133,12 +148,12 @@ public class ScenarioTest {
                     switch (target) {
                         case KAFKA -> {
                             try (var consumer = clientFactory.kafkaConsumer("groupId", properties)) {
-                                consumeAndEvaluate(topic, messages, consumer);
+                                consumeAndEvaluate(topic, consumer, recordAssertion);
                             }
                         }
                         case GATEWAY -> {
                             try (var consumer = clientFactory.gatewayConsumer("groupId", properties)) {
-                                consumeAndEvaluate(topic, messages, consumer);
+                                consumeAndEvaluate(topic, consumer, recordAssertion);
                             }
                         }
                     }
@@ -155,20 +170,20 @@ public class ScenarioTest {
     private static void produce(String topic, LinkedList<Scenario.Message> messages, KafkaProducer<String, String> producer) throws ExecutionException, InterruptedException {
         for (var message : messages) {
             var inputHeaders = new ArrayList<Header>();
-            for (var header : message.getHeaders().entrySet()) {
-                inputHeaders.add(new RecordHeader(header.getKey(), header.getValue().getBytes()));
+            if (Objects.nonNull(message.getHeaders())) {
+                for (var header : message.getHeaders().entrySet()) {
+                    inputHeaders.add(new RecordHeader(header.getKey(), header.getValue().getBytes()));
+                }
             }
             KafkaActionUtils.produce(producer, topic, message.getKey(), message.getValue(), inputHeaders);
         }
     }
 
-    private static void consumeAndEvaluate(String topic, LinkedList<Scenario.Message> messages, KafkaConsumer<String, String> consumer) {
-        var records = KafkaActionUtils.consume(consumer, topic, messages.size());
-        Assertions.assertThat(records.size()).isEqualTo(messages.size());
-        int i = 0;
-        for (var message : messages) {
-            var record = records.get(i++);
-            assertRecord(message, record);
+    private static void consumeAndEvaluate(String topic, KafkaConsumer<String, String> consumer, Scenario.RecordAssertion recordAssertion) {
+        var records = KafkaActionUtils.consume(consumer, topic, recordAssertion.getExpectedSize());
+        assertThat(records.size()).isEqualTo(recordAssertion.getExpectedSize());
+        for (var record : records) {
+            assertRecord(record, recordAssertion);
         }
     }
 
@@ -198,15 +213,50 @@ public class ScenarioTest {
         }
     }
 
-    private static void assertRecord(Scenario.Message output, ConsumerRecord<String, String> record) {
-        Assertions.assertThat(record.key()).matches(output.getKey());
-        Assertions.assertThat(record.value()).matches(output.getValue());
-        if (Objects.nonNull(output.getHeaders())) {
-            Assertions.assertThat(record.headers()).hasSize(output.getHeaders().size());
-            for (var outputHeader : output.getHeaders().entrySet()) {
-                var header = new RecordHeader(outputHeader.getKey(), outputHeader.getValue().getBytes());
-                Assertions.assertThat(record.headers()).contains(header);
+    private static void assertRecord(ConsumerRecord<String, String> record, Scenario.RecordAssertion recordAssertion) {
+        log.info("Start test: " + recordAssertion.getTitle());
+        assertData(record.key(), recordAssertion.getKey());
+        assertData(record.value(), recordAssertion.getValue());
+        if (Objects.nonNull(recordAssertion.getHeaders())) {
+            var recordHeaders = IteratorUtils.toList(record.headers().iterator())
+                    .stream()
+                    .collect(Collectors.toMap(Header::key, Header::value));
+            for (var entry : recordAssertion.getHeaders().entrySet()) {
+                assertTrue(recordHeaders.containsKey(entry.getKey()));
+                assertData(new String(recordHeaders.get(entry.getKey())), entry.getValue());
             }
+        }
+        log.info("Test done: " + recordAssertion.getTitle());
+    }
+
+    private static void assertData(String data, Scenario.Assertion assertion) {
+        if (Objects.isNull(assertion)) {
+            return;
+        }
+        var expected = assertion.getExpected();
+        var assertMethod = assertion.getAssertThat();
+        if (Objects.isNull(expected) || expected instanceof String str && StringUtils.isBlank(str)) {
+            return;
+        }
+        try {
+            if ("satisfies".equals(assertMethod)) {
+                var dataAsMap = MAPPER.readValue(data, new TypeReference<Map<String, Object>>() {
+                });
+                var parser = new SpelExpressionParser();
+                var context = new StandardEvaluationContext(dataAsMap);
+                context.setVariables(dataAsMap);
+
+                var satisfied = parser.parseExpression(String.valueOf(expected)).getValue(context, Boolean.class);
+                assertEquals(Boolean.TRUE, satisfied);
+                return;
+            }
+            //TODO: support more types
+            var method = AbstractAssert.class.getMethod(assertMethod, Object.class);
+            method.invoke(assertThat(data), expected);
+        } catch (NoSuchMethodException ex) {
+            fail("Assertion.assertThat '" + assertMethod + "' is not supported");
+        } catch (Throwable ex) {
+            fail(ExceptionUtils.getRootCause(ex));
         }
     }
 

--- a/src/test/java/io/conduktor/gateway/soak/func/ScenarioTest.java
+++ b/src/test/java/io/conduktor/gateway/soak/func/ScenarioTest.java
@@ -183,7 +183,9 @@ public class ScenarioTest {
         var i = 0;
         for (var record : records) {
             var assertion = recordAssertions.get(i++);
-            log.info("Test: " + assertion.getDescription());
+            if (StringUtils.isNotBlank(assertion.getDescription())) {
+                log.info("Test: " + assertion.getDescription());
+            }
             assertRecord(record, assertion);
         }
     }

--- a/src/test/java/io/conduktor/gateway/soak/func/ScenarioTest.java
+++ b/src/test/java/io/conduktor/gateway/soak/func/ScenarioTest.java
@@ -108,9 +108,7 @@ public class ScenarioTest {
             var target = action.getTarget();
             var properties = action.getProperties();
             var topic = action.getTopic();
-            var messages = action.getMessages();
             var clientFactory = new ClientFactory();
-            var recordAssertions = action.getAssertions();
 
             //TODO: refactor it to look better
             switch (type) {
@@ -129,29 +127,31 @@ public class ScenarioTest {
                     }
                 }
                 case PRODUCE -> {
+                    var produceAction = ((Scenario.ProduceAction) action);
                     switch (target) {
                         case KAFKA -> {
                             try (var kafkaProducer = clientFactory.kafkaProducer(properties)) {
-                                produce(topic, messages, kafkaProducer);
+                                produce(topic, produceAction.getMessages(), kafkaProducer);
                             }
                         }
                         case GATEWAY -> {
                             try (var producer = clientFactory.gatewayProducer(properties)) {
-                                produce(topic, messages, producer);
+                                produce(topic, produceAction.getMessages(), producer);
                             }
                         }
                     }
                 }
                 case FETCH -> {
+                    var fetchAction = ((Scenario.FetchAction) action);
                     switch (target) {
                         case KAFKA -> {
                             try (var consumer = clientFactory.kafkaConsumer("groupId", properties)) {
-                                consumeAndEvaluate(topic, consumer, recordAssertions);
+                                consumeAndEvaluate(topic, consumer, fetchAction.getAssertions());
                             }
                         }
                         case GATEWAY -> {
                             try (var consumer = clientFactory.gatewayConsumer("groupId", properties)) {
-                                consumeAndEvaluate(topic, consumer, recordAssertions);
+                                consumeAndEvaluate(topic, consumer, fetchAction.getAssertions());
                             }
                         }
                     }

--- a/src/test/java/io/conduktor/gateway/soak/func/config/Scenario.java
+++ b/src/test/java/io/conduktor/gateway/soak/func/config/Scenario.java
@@ -3,14 +3,11 @@ package io.conduktor.gateway.soak.func.config;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import lombok.ToString;
-import org.apache.kafka.common.protocol.ApiKeys;
 
 import java.util.LinkedHashMap;
 import java.util.LinkedList;
 
 @Data
-@ToString
 @NoArgsConstructor
 @AllArgsConstructor
 public class Scenario {
@@ -20,7 +17,6 @@ public class Scenario {
     private LinkedList<Action> actions;
 
     @Data
-    @ToString
     @NoArgsConstructor
     @AllArgsConstructor
     public static class Docker {
@@ -29,7 +25,6 @@ public class Scenario {
     }
 
     @Data
-    @ToString
     @NoArgsConstructor
     @AllArgsConstructor
     public static class Service {
@@ -39,7 +34,6 @@ public class Scenario {
     }
 
     @Data
-    @ToString
     @NoArgsConstructor
     @AllArgsConstructor
     public static class Action {
@@ -48,16 +42,35 @@ public class Scenario {
         private LinkedHashMap<String, String> properties;
         private String topic;
         private LinkedList<Message> messages;
+        private RecordAssertion recordAssertion;
     }
 
     @Data
-    @ToString
     @NoArgsConstructor
     @AllArgsConstructor
     public static class Message {
         private LinkedHashMap<String, String> headers;
         private String key;
         private String value;
+    }
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class RecordAssertion {
+        private String title;
+        private int expectedSize = 1;
+        private LinkedHashMap<String, Assertion> headers;
+        private Assertion key;
+        private Assertion value;
+    }
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class Assertion {
+        private String assertThat = "isEqualTo";
+        private Object expected;
     }
 
     public enum ActionType {

--- a/src/test/java/io/conduktor/gateway/soak/func/config/Scenario.java
+++ b/src/test/java/io/conduktor/gateway/soak/func/config/Scenario.java
@@ -42,7 +42,7 @@ public class Scenario {
         private LinkedHashMap<String, String> properties;
         private String topic;
         private LinkedList<Message> messages;
-        private RecordAssertion recordAssertion;
+        private LinkedList<RecordAssertion> assertions;
     }
 
     @Data
@@ -58,8 +58,7 @@ public class Scenario {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class RecordAssertion {
-        private String title;
-        private int expectedSize = 1;
+        private String description;
         private LinkedHashMap<String, Assertion> headers;
         private Assertion key;
         private Assertion value;
@@ -69,7 +68,7 @@ public class Scenario {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class Assertion {
-        private String assertThat = "isEqualTo";
+        private String operator = "isEqualTo";
         private Object expected;
     }
 

--- a/src/test/java/io/conduktor/gateway/soak/func/config/Scenario.java
+++ b/src/test/java/io/conduktor/gateway/soak/func/config/Scenario.java
@@ -1,7 +1,10 @@
 package io.conduktor.gateway.soak.func.config;
 
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 
 import java.util.LinkedHashMap;
@@ -33,6 +36,14 @@ public class Scenario {
         private LinkedHashMap<String, String> properties;
     }
 
+    @JsonTypeInfo(
+            use = JsonTypeInfo.Id.NAME,
+            property = "type")
+    @JsonSubTypes({
+            @JsonSubTypes.Type(value = ProduceAction.class, name = "PRODUCE"),
+            @JsonSubTypes.Type(value = FetchAction.class, name = "FETCH"),
+            @JsonSubTypes.Type(value = Action.class, name = "CREATE_TOPIC")
+    })
     @Data
     @NoArgsConstructor
     @AllArgsConstructor
@@ -41,7 +52,21 @@ public class Scenario {
         private ActionTarget target;
         private LinkedHashMap<String, String> properties;
         private String topic;
+    }
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @EqualsAndHashCode(callSuper = true)
+    public static class ProduceAction extends Action {
         private LinkedList<Message> messages;
+    }
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @EqualsAndHashCode(callSuper = true)
+    public static class FetchAction extends Action {
         private LinkedList<RecordAssertion> assertions;
     }
 

--- a/src/test/java/io/conduktor/gateway/soak/func/config/Scenario.java
+++ b/src/test/java/io/conduktor/gateway/soak/func/config/Scenario.java
@@ -38,7 +38,8 @@ public class Scenario {
 
     @JsonTypeInfo(
             use = JsonTypeInfo.Id.NAME,
-            property = "type")
+            property = "type",
+            visible = true)
     @JsonSubTypes({
             @JsonSubTypes.Type(value = ProduceAction.class, name = "PRODUCE"),
             @JsonSubTypes.Type(value = FetchAction.class, name = "FETCH"),


### PR DESCRIPTION
What does this PR do?

- Integrating encryption interceptor
- Today record resources (key, value, title) only support assert with regex
-> Supports more assertions, see more in [README.md](https://github.com/conduktor/conduktor-gateway-soak-func/tree/linh/encryption#actions)